### PR TITLE
Moved the theme selector to right of search

### DIFF
--- a/js/nav/view.html
+++ b/js/nav/view.html
@@ -11,22 +11,8 @@
 		</span>
 	</div>
 </div>
-<div class="padding-2 {:this.app.menuOpen ? '' : 'hidden-state':}|{menuOpen}|"><!-- toggleable dropdown -->
-	<div class="flex">
-		<span class="grow text-center">Theme:</span>
-		<select onchange="this.app.configs.theme = this.value" class="grow" data-value="{:this.app.configs.theme:}|{configs.theme}|">
-			<option value="oled">
-				OLED Black
-			</option>
-			<option value="dark">
-				Dark
-			</option>
-			<option value="">
-				Light
-			</option>
-		</select>
-	</div>
-	<div class="flex column-smol row-mid">
+<div class="padding-2 {:this.app.menuOpen ? '' : 'hidden-state':}|{menuOpen}|"><!-- toggleable dropdown --> 
+<div class="flex column-smol row-mid">
 		<div class="basis">
 			<div class="padding-1"></div>
 			<div class="text-center">
@@ -63,11 +49,14 @@
 		</div>
 		<div class="basis">
 			<div class="padding-1"></div>
-<!--
 			<div class="text-center">
-				<a class="button inline block" target="_blank">Some Button</a>
+				<span class="grow text-center">Theme: </span>
+				<select onchange="this.app.configs.theme = this.value" class="grow" data-value="{:this.app.configs.theme:}|{configs.theme}|">
+					<option value="oled">OLED Black</option>
+					<option value="dark">Dark</option>
+					<option value="">Light</option>
+				</select>
 			</div>
--->
 		</div>
 	</div>
 	<div>


### PR DESCRIPTION
Moved the theme selector to right of search, I'll close the previous PR since it turned out really messy. Apparently those "Learn Git in 15 min Crashcourse" youtube videos don't make you an expert in git and contributing to real projects.

Anyways here the change:
![image](https://user-images.githubusercontent.com/25026173/103026822-b3cfd180-457a-11eb-97ce-56836b8e2201.png)
![image](https://user-images.githubusercontent.com/25026173/103026846-c2b68400-457a-11eb-8e1f-73d3e4f591cb.png)
