### PR TITLE
New Calibre inspired themes

### DIFF
--- a/css/themes.css
+++ b/css/themes.css
@@ -14,3 +14,20 @@
 	--color-dark: #CBCBCB;
 	--color-black: #EEE;
 }
+.sepialight {
+    --color-white: #F6F3E9;
+    --color-light: #b78f5c;
+    --color-mid: #F6F3E9;
+    --color-low: #442d2d;
+    --color-dark: #000;
+    --color-black: #39322B;
+    --color-primary: #99bdf9;
+}
+.sepiadark {
+    --color-white: #39322a;
+    --color-light: #594e47;
+    --color-mid: #39322a;
+    --color-low: #938B8B;
+    --color-dark: #f5f0d2;
+    --color-black: #EEE;
+}

--- a/js/main.js
+++ b/js/main.js
@@ -12,11 +12,11 @@ async function app(initConfigs){
 
 	function updateTheme(newTheme){
 		if (newTheme && !document.documentElement.classList.contains(newTheme)){
-			document.documentElement.classList.remove("oled", "dark")
+			document.documentElement.classList.remove("oled", "dark", "sepialight", "sepiadark")
 			document.documentElement.classList.add(newTheme)
 		}
 		else if (!newTheme){
-			document.documentElement.classList.remove("oled", "dark")
+			document.documentElement.classList.remove("oled", "dark", "sepialight", "sepiadark")
 		}
 
 		app.saveSettings()

--- a/js/nav/view.html
+++ b/js/nav/view.html
@@ -54,6 +54,10 @@
 				<select onchange="this.app.configs.theme = this.value" class="grow" data-value="{:this.app.configs.theme:}|{configs.theme}|">
 					<option value="oled">OLED Black</option>
 					<option value="dark">Dark</option>
+					<!-- Note to those who see this from Ettezo:
+					These two themes given below were inspired by Calibre's sepia themes and modified to suit this web app. Hence Caliber and not Calibre ;) -->
+					<option value="sepialight">Caliber Sepia Light</option> 
+					<option value="sepiadark">Caliber Sepia Dark</option>
 					<option value="">Light</option>
 				</select>
 			</div>


### PR DESCRIPTION
I've added two new themes inspired from Calibre ebook reader's sepia themes.
Both of the sepia theme from calibre have been modified to suit this web app and they've been named Caliber and not Calibre ;)

Why these themes?
Well first of all there are a lot of people who love Calibre and why not? everyone loves more options :p

Here is the preview:
Desktop:
![DarkSepia Frontpage](https://user-images.githubusercontent.com/25026173/104547944-bee7c000-5655-11eb-86ac-599b3cbf2312.png)
![DarkSepia Reader](https://user-images.githubusercontent.com/25026173/104547930-b8f1df00-5655-11eb-808c-4103fef96826.png)
![LightSepia Frontpage](https://user-images.githubusercontent.com/25026173/104547939-bc856600-5655-11eb-95ea-c8a18245b9ee.png)
![LightSepia Reader](https://user-images.githubusercontent.com/25026173/104547942-bdb69300-5655-11eb-86b7-2bdffe954d33.png)

Mobile:
![Screen Shot 2021-01-14 at 10 51 26](https://user-images.githubusercontent.com/25026173/104548371-ac21bb00-5656-11eb-8aab-6b116deadc5c.png)
![Screen Shot 2021-01-14 at 10 52 04](https://user-images.githubusercontent.com/25026173/104548347-9dd39f00-5656-11eb-82bb-96d34a9f6d91.png)
![Screen Shot 2021-01-14 at 10 52 19](https://user-images.githubusercontent.com/25026173/104548368-aa57f780-5656-11eb-8f7c-876e771ccc74.png)
![Screen Shot 2021-01-14 at 10 52 11](https://user-images.githubusercontent.com/25026173/104548360-a75d0700-5656-11eb-9666-5a2df238e2b6.png)


